### PR TITLE
Up the default number of open files allowed 

### DIFF
--- a/assets/nodes/supervisord.conf
+++ b/assets/nodes/supervisord.conf
@@ -5,7 +5,7 @@ logfile_backups=10           ; (num of main logfile rotation backups;default 10)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
 pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 nodaemon=false               ; (start in foreground if true;default false)
-minfds=1024                  ; (min. avail startup file descriptors;default 1024)
+minfds=65536                 ; (min. avail startup file descriptors;default 1024)
 minprocs=200                 ; (min. avail process descriptors;default 200)
 
 [supervisorctl]


### PR DESCRIPTION
Up the default number of open files allowed for a process under supervisor (neo-cli will regularly go over the default of 1024)